### PR TITLE
Add priority to queue settings

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 		MessageTTL           int
 		DeadLetterExchange   string
 		DeadLetterRoutingKey string
+		Priority             int
 	}
 	Exchange struct {
 		Name       string
@@ -134,6 +135,16 @@ func (c Config) HasDeadLetterRouting() bool {
 // DeadLetterRoutingKey returns the configured key for the dead letter routing.
 func (c Config) DeadLetterRoutingKey() string {
 	return transformToStringValue(c.QueueSettings.DeadLetterRoutingKey)
+}
+
+// HasPriority checks if priority is configured
+func (c Config) HasPriority() bool {
+	return c.QueueSettings.Priority > 0
+}
+
+// Priority returns the priority
+func (c Config) Priority() int32 {
+	return int32(c.QueueSettings.Priority)
 }
 
 func LoadAndParse(location string) (*Config, error) {

--- a/consumer/connection.go
+++ b/consumer/connection.go
@@ -157,6 +157,10 @@ func (c *rabbitMqConnection) queueArgs() amqp.Table {
 		}
 	}
 
+	if c.cfg.HasPriority() {
+		args["x-max-priority"] = c.cfg.Priority()
+	}
+
 	if len(args) > 0 {
 		return args
 	}

--- a/example.conf
+++ b/example.conf
@@ -99,6 +99,9 @@ deadLetterExchange = someexchange
 # The routing key used when sending a message to the dead letter exchange.
 deadLetterroutingkey = someroutingkey
 
+# The priority range for this queue.
+priority = 10
+
 [logs]
 # Path to the log file where informational output is written to
 # #


### PR DESCRIPTION
Hi @corvus-ch ,

It's really nice that you took back ricbra consumer, i did a PR on it a while ago ( ricbra/rabbitmq-cli-consumer#56 ) and since you are the official fork i adapted it taking your modifications into account.

I added the property `x-max-priority` to the queue settings, added test and example.

Tell me if you want me to do any modification.

Thanks !