### PR TITLE
Add the possibility to bind multiple routing keys

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,7 +25,7 @@ type Config struct {
 		Global bool
 	}
 	QueueSettings struct {
-		Routingkey           string
+		Routingkey           []string
 		MessageTTL           int
 		DeadLetterExchange   string
 		DeadLetterRoutingKey string
@@ -112,9 +112,13 @@ func (c Config) MessageTTL() int32 {
 	return int32(c.QueueSettings.MessageTTL)
 }
 
-// RoutingKey returns the configured key for message routing.
-func (c Config) RoutingKey() string {
-	return transformToStringValue(c.QueueSettings.Routingkey)
+// RoutingKeys returns the configured keys for message routing.
+func (c Config) RoutingKeys() []string {
+	if len(c.QueueSettings.Routingkey) < 1 {
+		return []string{""}
+	}
+
+	return transformArrayOfStringToStringValue(c.QueueSettings.Routingkey)
 }
 
 // HasDeadLetterExchange checks if a dead letter exchange is configured.
@@ -181,4 +185,14 @@ func transformToStringValue(val string) string {
 	}
 
 	return val
+}
+
+func transformArrayOfStringToStringValue(iterable []string) []string {
+	var ret []string
+
+	for _, str := range iterable {
+		ret = append(ret, transformToStringValue(str))
+	}
+
+	return ret
 }

--- a/consumer/connection.go
+++ b/consumer/connection.go
@@ -128,14 +128,16 @@ func (c *rabbitMqConnection) declareExchange() error {
 
 	// Bind queue
 	c.outLog.Printf("Binding queue \"%s\" to exchange \"%s\"...", c.cfg.RabbitMq.Queue, c.cfg.Exchange.Name)
-	if err := c.ch.QueueBind(
-		c.cfg.RabbitMq.Queue,
-		c.cfg.RoutingKey(),
-		c.cfg.ExchangeName(),
-		false,
-		nil,
-	); err != nil {
-		return fmt.Errorf("failed to bind queue to exchange: %v", err)
+	for _, routingKey := range c.cfg.RoutingKeys() {
+		if err := c.ch.QueueBind(
+			c.cfg.RabbitMq.Queue,
+			routingKey,
+			c.cfg.ExchangeName(),
+			false,
+			nil,
+		); err != nil {
+			return fmt.Errorf("failed to bind queue to exchange: %v", err)
+		}
 	}
 
 	return nil

--- a/example.conf
+++ b/example.conf
@@ -85,8 +85,9 @@ durable = On
 # settings.
 [queuesettings]
 # The routing key used to determine if a message send to the above configured
-# exchange will be routed to the queue.
+# exchange will be routed to the queue. Multiple routing keys can be configured.
 routingkey = somekey
+routingkey = anotherkey
 
 # The default TTL of a message in the queue.
 #


### PR DESCRIPTION
Hi,

I adapted the work of @sterrien in ricbra/rabbitmq-cli-consumer#59 adding the possibility to bind multiple routing key to a queue. I added test to it.

Tell me if you want any modification, i'll be glad to do them !

Thanks !